### PR TITLE
.Dialog改动.文档更新

### DIFF
--- a/docs/templates/dialog.jade
+++ b/docs/templates/dialog.jade
@@ -22,7 +22,7 @@ block content
 
   p.sui-lead
     | 对话框分为独占式和非独占式两种。<br />
-    | 宽度分为三种：450px,600px,800px。最小高度为260px。可以根据业务需求自行调整。
+    | 注意href属性用来指向对话框主体元素或远程内容url，除此之外<code>不要设置其他href值</code><br>
     | 文档写的渣，有任何疑惑可以联系@半边。
 
   h2 概览
@@ -237,6 +237,7 @@ block content
          hasfoot: {Boolean}  是否显示脚部  默认true
          width: {number|string(px)|'small'|'normal'|'large'}推荐优先使用后三个描述性字符串，统一样式
          height: {number|string(px)} 内容区（.modal-body）高度
+         remote: {string} 如果提供了远程url地址，就会加载远端内容
          timeout: {number} 1000    单位毫秒ms ,对话框打开后多久自动关闭
          show:     fn --------------function(e){}
          shown:    fn

--- a/docs/templates/dialog.jade
+++ b/docs/templates/dialog.jade
@@ -22,7 +22,7 @@ block content
 
   p.sui-lead
     | 对话框分为独占式和非独占式两种。<br />
-    | 注意href属性用来指向对话框主体元素或远程内容url，除此之外<code>不要设置其他href值</code><br>
+    | 注意href属性可用来指向对话框主体元素,不再能引用远程内容url<br>
     | 文档写的渣，有任何疑惑可以联系@半边。
 
   h2 概览
@@ -131,7 +131,7 @@ block content
             td remote
             td path
             td false
-            td 如果提供了远程url地址，就会通过 jQuery的load方法加载内容并注入到<code>.modal-body</code>中。如果你使用的是data属性api，你还可以使用<code>href</code>标签指定远程数据源。案例如下
+            td 如果提供了远程url地址，就会通过 jQuery的load方法加载内容并注入到<code>.modal-body</code>中。案例如下
               pre.prettyprint &lt;a data-toggle="modal" href="remote.html" data-target="#modal"&gt;click me&lt;/a&gt;
     div.tab-pane#event1
       p 原型方法的事件接口,与bootstrap提供的一致,与静态方法不互用

--- a/js/modal.js
+++ b/js/modal.js
@@ -330,7 +330,8 @@
       //$target这里指dialog本体Dom(若存在)
       //通过data-target="#foo"或href="#foo"指向
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
-      , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $this.data())
+      //remote,href属性如果以#开头，表示等同于data-target属性
+      , option = $target.data('modal') ? 'toggle' : $.extend({ remote: !!href.length && !/#/.test(href) && href }, $this.data())
     e.preventDefault()
     $target
       .modal(option)
@@ -353,6 +354,7 @@
    *  height: {number|string(px)} 高度
    *  timeout: {number} 1000    单位毫秒ms ,dialog打开后多久自动关闭
    *  hasfoot: {Boolean}  是否显示脚部  默认true
+   *  remote: {string} 如果提供了远程url地址，就会加载远端内容
    *  show:     fn --------------function(e){}
    *  shown:    fn
    *  hide:     fn

--- a/js/modal.js
+++ b/js/modal.js
@@ -331,7 +331,7 @@
       //通过data-target="#foo"或href="#foo"指向
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       //remote,href属性如果以#开头，表示等同于data-target属性
-      , option = $target.data('modal') ? 'toggle' : $.extend({ remote: !!href.length && !/#/.test(href) && href }, $this.data())
+      , option = $target.data('modal') ? 'toggle' : $this.data()
     e.preventDefault()
     $target
       .modal(option)


### PR DESCRIPTION
data-remote不再能接受href传入的url地址。
依然能作为指向对话框本体元素的指针。
